### PR TITLE
Fix for AbstractObservableList#nullIfEqual

### DIFF
--- a/modules/quitte/src/main/java/com/osmerion/quitte/collections/AbstractObservableList.java
+++ b/modules/quitte/src/main/java/com/osmerion/quitte/collections/AbstractObservableList.java
@@ -198,6 +198,7 @@ public abstract class AbstractObservableList<E> extends AbstractList<E> implemen
         boolean aHasNext, bHasNext;
         while ((aHasNext = aItr.hasNext()) & (bHasNext = bItr.hasNext())) {
             E element = bItr.next();
+            copyOfElements.add(element);
 
             if (!Objects.equals(aItr.next(), element)) {
                 equal = false;


### PR DESCRIPTION
Fixed `AbstractObservableList#nullIfEqual` not copying all elements. Fixes #5.